### PR TITLE
feat: support Xcode 14 mappings

### DIFF
--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -210,6 +210,33 @@ const simulatorDevicePairCompatibility = {
 			'7.x': true,        // watchOS 7.x
 			'8.x': true         // watchOS 8.x
 		}
+	},
+	'14.x': {                   // Xcode 14.x
+		'12.x': {               // iOS 12.x
+			'7.x': true,        // watchOS 7.x
+			'8.x': true,        // watchOS 8.x
+			'9.x': true			// watchOS 9.x
+		},
+		'13.x': {               // iOS 13.x
+			'7.x': true,        // watchOS 7.x
+			'8.x': true,        // watchOS 8.x
+			'9.x': true			// watchOS 9.x
+		},
+		'14.x': {               // iOS 14.x
+			'7.x': true,        // watchOS 7.x
+			'8.x': true,        // watchOS 8.x
+			'9.x': true			// watchOS 9.x
+		},
+		'15.x': {
+			'7.x': true,        // watchOS 7.x
+			'8.x': true,        // watchOS 8.x
+			'9.x': true			// watchOS 9.x
+		},
+		'16.x': {
+			'7.x': true,        // watchOS 7.x
+			'8.x': true,        // watchOS 8.x
+			'9.x': true			// watchOS 9.x
+		}
 	}
 };
 


### PR DESCRIPTION
- [x] Add mappings for Xcode 14, based on the available device in Xcode / `simctl`
- [ ] Remove obviously unsupported Xcode mappings (e.g. Xcode 6-11 -> no one can run anything of that anymore), TBD