### PR TITLE
fix: ensure xcode.js change can run on node 14.x

### DIFF
--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -598,7 +598,7 @@ exports.detect = function detect(options, callback) {
 							// - com.apple.CoreSimulator.SimRuntime.watchOS-10-0
 							for (const key of Object.keys(info.devices)) {
 								const [_, platform, rawVersion] = key.match(/\.SimRuntime\.(.*?)\-(.*)$/);
-								const version = rawVersion.replaceAll('-', '.');
+								const version = rawVersion.replace(/-/g, '.');
 
 								const mapping = {
 									name: `${platform} ${version}`,


### PR DESCRIPTION
Ensure xcode.js change that uses replaceAll can run on node 14.x by replacing replaceAll with replace and a regex pattern instead