### PR TITLE
fix: supports now also MacCatalyst .provisioningprofile and iOS .mobileprovision

### DIFF
--- a/lib/provisioning.js
+++ b/lib/provisioning.js
@@ -80,7 +80,9 @@ function detect(options, callback) {
 				enterprise: 0,
 				distribution: 0
 			},
-			ppRegExp = /.+\.mobileprovision$/;
+
+			ppRegExp = /.*\.(mobileprovision|provisionprofile)$/;
+			
 
 		if (options.watch) {
 			var throttleTimer = null;
@@ -236,7 +238,7 @@ function detect(options, callback) {
 					team: plist.TeamIdentifier || null,
 					entitlements: entitlements,
 					// TODO: remove all of the entitlements below and just use the `entitlements` property
-					appId: (entitlements['application-identifier'] || '').replace(appPrefix + '.', ''),
+					appId: (entitlements['application-identifier'] || entitlements['com.apple.application-identifier'] || '').replace(appPrefix + '.', ''),
 					getTaskAllow: !!entitlements['get-task-allow'],
 					apsEnvironment: entitlements['aps-environment'] || ''
 				});


### PR DESCRIPTION

Profiles are now found, also in combination with VSCode-Extension PR https://github.com/tidev/vscode-titanium/pull/1173