### PR TITLE
chore: add help text to assist when no Simulators are available

### DIFF
--- a/lib/simulator.js
+++ b/lib/simulator.js
@@ -771,11 +771,13 @@ function findSimulators(options, callback) {
 				}
 
 				if (!simHandle) {
+					const helpText = '\n\nPlease open Xcode, navigate to "Window > Devices and Simulators" and create a new Simulator with your preferred configuration.';
+
 					// user experience!
 					if (options.simVersion) {
-						return callback(new Error(__('Unable to find an iOS Simulator running iOS %s.', options.simVersion)));
+						return callback(new Error(__(`Unable to find an iOS Simulator running iOS %s. ${helpText}`, options.simVersion)));
 					} else {
-						return callback(new Error(__('Unable to find an iOS Simulator.')));
+						return callback(new Error(__(`Unable to find an iOS Simulator. ${helpText}`)));
 					}
 				} else if (options.watchAppBeingInstalled && !watchSimHandle) {
 					return callback(new Error(__('Unable to find a watchOS Simulator that supports watchOS %s', options.watchMinOSVersion)));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ioslib",
-  "version": "1.7.34",
+  "version": "1.7.35",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ioslib",
-      "version": "1.7.34",
+      "version": "1.7.35",
       "license": "Apache-2.0",
       "dependencies": {
         "always-tail": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ioslib",
-  "version": "1.7.34",
+  "version": "1.7.35",
   "description": "iOS Utility Library",
   "keywords": [
     "appcelerator",


### PR DESCRIPTION
Xcode does not auto-create Simulators anymore. Before a long-term solution is added (fetch sims, fetch runtimes, create and link sim), this will resolve all user questions regarding this question already. I am not even sure if we should auto-create them at all, as Xcode offers the perfect UI to list, preview, create and link Simulators already.