### PR TITLE
fix: make sure to terminate running processes before launching app

### DIFF
--- a/lib/simctl.js
+++ b/lib/simctl.js
@@ -146,7 +146,7 @@ function launch(params, callback) {
 		return callback(new Error(__('Missing "appId" param')));
 	}
 
-	trySimctl(params, ['launch', params.udid, params.appId], callback);
+	trySimctl(params, ['launch', '--terminate-running-process', params.udid, params.appId], callback);
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ioslib",
-  "version": "1.7.37",
+  "version": "1.7.38",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ioslib",
-      "version": "1.7.36",
+      "version": "1.7.38",
       "license": "Apache-2.0",
       "dependencies": {
         "always-tail": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ioslib",
-  "version": "1.7.37",
+  "version": "1.7.38",
   "description": "iOS Utility Library",
   "keywords": [
     "appcelerator",


### PR DESCRIPTION
This PR fixes an issue for Xcode 16+ and `ti build` (not happening with LiveView) where the app would launch in an corrupted state after an incremental build. It seems to be a Xcode 16 regression that can be fixed by making sure to terminate running processes before installing the new build.

Reported by @max87za via https://github.com/tidev/titanium-sdk/issues/14121

### Test case:

1. Run an app with Xcode 16, e.g. `ti build -p ios`
2. Keep the simulator open and run the app again

Expected behavior: The new version is installed
Actual behavior: The app hangs in the old state or gets partially updated