### PR TITLE
fix: use “simctl list” to fetch device types, not file i/o

### DIFF
--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -553,7 +553,7 @@ exports.detect = function detect(options, callback) {
 
 					Object.keys(simulatorDevicePairCompatibility).some(function (xcodeRange) {
 						if (appc.version.satisfies(xc.version, xcodeRange)) {
-							xc.simDevicePairs = simulatorDevicePairCompatibility[xcodeRange];
+							xc.simDevicePairs = simulatorDevicePairCompatibility[xcodeRange];	
 
 							// use the device pair compatibility to see if the simruntime is supported by
 							// this Xcode as there isn't a way to programmatically do it
@@ -576,71 +576,48 @@ exports.detect = function detect(options, callback) {
 						}
 					});
 
-					var deviceTypesPaths = [
-						path.join(xc.path, 'Platforms', 'iPhoneSimulator.platform', 'Developer', 'Library', 'CoreSimulator', 'Profiles'),
-						path.join(xc.path, 'Platforms', 'WatchSimulator.platform', 'Developer', 'Library', 'CoreSimulator', 'Profiles'),
+					// Read the device types and devices in one call using the `xcrun simctl list --json`
+					// command. This not only improves performance (no device I/O required), but also combines
+					// two command (`simctl list` and `simctl list devices`) into one.
+					simctl.list({ simctl: xc.executables.simctl }, function (err, info) {
+						if (err) {
+							return next(err);
+						}
 
-						// Xcode 9 moved CoreSimulator into the "OS" directory instead of the "Simulator" directory
-						path.join(xc.path, 'Platforms', 'iPhoneOS.platform', 'Developer', 'Library', 'CoreSimulator', 'Profiles'),
-						path.join(xc.path, 'Platforms', 'WatchOS.platform', 'Developer', 'Library', 'CoreSimulator', 'Profiles'),
-
-						// Xcode 11 moved CoreSimulator into the "Library/Developer" directory instead of the "Developer/Library" directory
-						path.join(xc.path, 'Platforms', 'iPhoneOS.platform', 'Library', 'Developer', 'CoreSimulator', 'Profiles'),
-						path.join(xc.path, 'Platforms', 'WatchOS.platform', 'Library', 'Developer', 'CoreSimulator', 'Profiles')
-					];
-
-					deviceTypesPaths.forEach(function (deviceTypePath) {
-						// read in the device types
-						var deviceTypesDir = path.join(deviceTypePath, 'DeviceTypes');
-						fs.existsSync(deviceTypesDir) && fs.readdirSync(deviceTypesDir).forEach(function (name) {
-							var plist = readPlist(path.join(deviceTypesDir, name, 'Contents', 'Info.plist')),
-								devId = plist && plist.CFBundleIdentifier;
-							if (plist) {
-								var deviceType = xc.simDeviceTypes[devId] = {
-									name: plist.CFBundleName,
-									model: 'unknown',
-									supportsWatch: false
-								};
-
-								plist = readPlist(path.join(deviceTypesDir, name, 'Contents', 'Resources', 'profile.plist'));
-								if (plist) {
-									deviceType.model = plist.modelIdentifier;
-								}
-
-								plist = readPlist(path.join(deviceTypesDir, name, 'Contents', 'Resources', 'capabilities.plist'));
-								if (plist) {
-									deviceType.supportsWatch = !!plist.capabilities['watch-companion'];
-								}
-							}
-						});
-
-						simctl.listDevices({ simctl: xc.executables.simctl }, function (err, info) {
-							if (err) {
-								return next(err);
-							}
+						const devices = info.devices;
+						const deviceTypes = info.devicetypes;
 	
-							// Map the platform and version from CoreSimulator string like:
-							// - com.apple.CoreSimulator.SimRuntime.iOS-17-0
-							// - com.apple.CoreSimulator.SimRuntime.watchOS-10-0
-							for (const key of Object.keys(info.devices)) {
-								const [_, platform, rawVersion] = key.match(/\.SimRuntime\.(.*?)\-(.*)$/);
-								const version = rawVersion.replace(/-/g, '.');
-
-								const mapping = {
-									name: `${platform} ${version}`,
-									version
-								}
-								appc.util.mix(xc.simRuntimes, { [key]: mapping });
-
+						deviceTypes.forEach(function(deviceType) {							
+							if (!xc.simDeviceTypes[deviceType.identifier]) {
+								xc.simDeviceTypes[deviceType.identifier] = {
+									name: deviceType.name,
+									model: deviceType.modelIdentifier || 'unknown',
+									// Assume devices with Watch in name or model support watch pairing
+									supportsWatch: /watch/i.test(deviceType.name) ? false : true
+								};
 							}
 						});
+
+						// Map the platform and version from CoreSimulator string like:
+						// - com.apple.CoreSimulator.SimRuntime.iOS-17-0
+						// - com.apple.CoreSimulator.SimRuntime.watchOS-10-0
+						for (const key of Object.keys(devices)) {
+							const [_, platform, rawVersion] = key.match(/\.SimRuntime\.(.*?)\-(.*)$/);
+							const version = rawVersion.replace(/-/g, '.');
+
+							const mapping = {
+								name: `${platform} ${version}`,
+								version
+							}
+							appc.util.mix(xc.simRuntimes, { [key]: mapping });
+						}	
 					});
 
 					['Simulator', 'iOS Simulator'].some(function (name) {
 						var p = path.join(dir, 'Applications', name + '.app', 'Contents', 'MacOS', name);
 						if (fs.existsSync(p)) {
 							xc.executables.simulator = p;
-							return true;
+							return true;		
 						}
 					});
 
@@ -669,7 +646,7 @@ exports.detect = function detect(options, callback) {
 									dest.push(ver);
 								}
 							}
-						});
+						});	
 
 						xc.sims.sort();
 						xc.watchos.sims.sort();

--- a/lib/xcode.js
+++ b/lib/xcode.js
@@ -553,7 +553,7 @@ exports.detect = function detect(options, callback) {
 
 					Object.keys(simulatorDevicePairCompatibility).some(function (xcodeRange) {
 						if (appc.version.satisfies(xc.version, xcodeRange)) {
-							xc.simDevicePairs = simulatorDevicePairCompatibility[xcodeRange];	
+							xc.simDevicePairs = simulatorDevicePairCompatibility[xcodeRange];
 
 							// use the device pair compatibility to see if the simruntime is supported by
 							// this Xcode as there isn't a way to programmatically do it
@@ -617,7 +617,7 @@ exports.detect = function detect(options, callback) {
 						var p = path.join(dir, 'Applications', name + '.app', 'Contents', 'MacOS', name);
 						if (fs.existsSync(p)) {
 							xc.executables.simulator = p;
-							return true;		
+							return true;
 						}
 					});
 
@@ -646,7 +646,7 @@ exports.detect = function detect(options, callback) {
 									dest.push(ver);
 								}
 							}
-						});	
+						});
 
 						xc.sims.sort();
 						xc.watchos.sims.sort();


### PR DESCRIPTION
Wow, this was HARD to find..but this is what's happening:
- Xcode 16.3 does not embed the device types (`<device>.simdevicetype`) under `Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/DeviceTypes` anymore, in fact, the whole `CoreSimulator` folder was nuked
- Luckily, `xcrun simctl list --json` already returns them pre-formatted, so Apple likely decided to sunset the additional files
- We now use that API to fetch the required model identifier and Watch support state
- The following call (to check the devices from simctl) can then be merged into one loop to do all work in one step

Note: ~~I have ditched the legacy code, so ioslib will only be compatible with Xcode 16.3+. As earlier versions use an earlier ioslib version anyway, I don't see a practical issue with that. If it is, feel free to extend this PR to restore that legacy code.~~ The "devicetypes" key in `xcrun simctl list --json` is actually available since a while now, so we can retain backwards compatibility without issues!